### PR TITLE
Add docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,11 @@ Running rgit in Docker is also simple, just mount the directory containing your 
 docker run --mount type=bind,source=/path/to/my-repos,target=/git \
   -it ghcr.io/w4/rgit:main
 ```
+
+#### Docker Compose
+
+An example `docker-compose.yml` is provided for those who prefer using Compose. To configure the UID and GID, the user is specified in `docker-compose.override.yml`. 
+
+An example override file has been has been provided with the repository. To use it, remove the `.example` extension from `docker-compose.override.yml.example`, and adjust the UID and GID to match the user that owns the directory containing your repositories.
+
+Afterwards, bring up the container with `docker-compose up` to make sure everything works.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  rgit:
+    user: 1000:1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  rgit:
+    image: ghcr.io/w4/rgit:main
+    volumes:
+      - /path/to/my-repos:/git
+    ports:
+      - 3333:8000
+    restart: unless-stopped


### PR DESCRIPTION
This is a sample `docker-compose.yml` and `docker-compose.override.yml` for those that don't like `docker run` (like myself). I also tested this with user permissions. The first run is without the user IDs and the second is with.

```zsh
➜  rgit git:(docker-fix) ✗ docker-compose up
Creating rgit_rgit_1 ... done
Attaching to rgit_rgit_1
rgit_1  | 2023-08-28T19:10:11.093150Z  INFO rgit: Running periodic index
rgit_1  | 2023-08-28T19:10:11.094482Z  INFO index_update: rgit::database::indexer: Starting index update
rgit_1  | thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { code: -36, klass: 7, message: "repository path '/git/slabs-from-wood.git/' is not owned by current user" }', src/database/indexer.rs:47:79
rgit_1  | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
^CGracefully stopping... (press Ctrl+C again to force)
Stopping rgit_rgit_1 ... 
Killing rgit_rgit_1  ... done
ERROR: 2
➜  rgit git:(docker-fix) ✗ ls
build.rs    Cargo.toml                           docker-compose.yml  flake.lock  LICENSE    rustfmt.toml  statics
Cargo.lock  docker-compose.override.yml.example  Dockerfile          flake.nix   README.md  src           templates
➜  rgit git:(docker-fix) ✗ mv docker-compose.override.yml.example docker-compose.override.yml         
➜  rgit git:(docker-fix) ✗ docker container rm rgit_rgit_1 
rgit_rgit_1
➜  rgit git:(docker-fix) ✗ docker-compose up
Creating rgit_rgit_1 ... done
Attaching to rgit_rgit_1
rgit_1  | 2023-08-28T19:10:50.584989Z  INFO rgit: Running periodic index
rgit_1  | 2023-08-28T19:10:50.585020Z  INFO index_update: rgit::database::indexer: Starting index update
rgit_1  | 2023-08-28T19:10:50.592146Z  INFO index_update:branch_index_update{reference="refs/heads/main" repository="REDACTED.git"}: rgit::database::indexer: Refreshing indexes
rgit_1  | 2023-08-28T19:10:50.595948Z  INFO index_update:branch_index_update{reference="refs/heads/main" repository="rgit.git"}: rgit::database::indexer: Refreshing indexes
rgit_1  | 2023-08-28T19:10:50.601467Z  INFO index_update:branch_index_update{reference="refs/heads/master" repository="slabs-from-wood.git"}: rgit::database::indexer: Refreshing indexes
rgit_1  | 2023-08-28T19:10:50.606221Z  INFO index_update:tag_index_update{reference="refs/tags/0.1.0" repository="rgit.git"}: rgit::database::indexer: Inserting newly discovered tag to index
rgit_1  | 2023-08-28T19:10:50.606734Z  INFO index_update: rgit::database::indexer: Flushing to disk
rgit_1  | 2023-08-28T19:10:50.606977Z  INFO index_update: rgit::database::indexer: Finished index update
rgit_1  | 2023-08-28T19:10:50.607002Z  INFO rgit: Finished periodic index
rgit_1  | 2023-08-28T19:11:00.995016Z  INFO web{request_id="8c8347d5-cbfb-46b7-987e-add455f5a966"}: rgit::layers::logger: [::ffff:192.168.2.12]:57054 - "GET /" 200 294.553µs "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0" "Ok(())"
rgit_1  | 2023-08-28T19:11:01.088605Z  INFO web{request_id="b45b0a21-a86f-4e41-822a-850ce1701633"}: rgit::layers::logger: [::ffff:192.168.2.12]:57054 - "GET /style.css" 200 12.384µs "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0" "Ok(())"
^CGracefully stopping... (press Ctrl+C again to force)
Stopping rgit_rgit_1 ... 
Killing rgit_rgit_1  ... done
ERROR: 2
```