### PR TITLE
Dockerfile: Drop user nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ RUN apt-get update && apt-get install -y libssl-dev pkg-config
 COPY . /sources
 WORKDIR /sources
 RUN cargo build --release
-RUN chown nobody:nogroup /sources/target/release/rgit
 
 FROM debian:bullseye-slim
 COPY --from=builder /sources/target/release/rgit /rgit
 
-USER nobody
 EXPOSE 8000
 ENTRYPOINT ["/rgit", "[::]:8000", "/git", "-d", "/tmp/rgit-cache.db"]


### PR DESCRIPTION
Docker user has to be set with --user UID:GID
to match UID and GID of the git repositoris on the filesystem to avoid 'repository path '/git/foo/' is not owned by current user' errors.

Ownership of the executable doesn't matter.